### PR TITLE
Fixed the build errors with dmd v2.067.0

### DIFF
--- a/cmdopt.d
+++ b/cmdopt.d
@@ -30,7 +30,7 @@ module cmdopt;
 
 import std.stdio;
 import std.getopt;
-import std.process;
+import std.c.process;
 
 class CmdOptions
 {

--- a/lexer.d
+++ b/lexer.d
@@ -227,7 +227,7 @@ final class Lexer
         return "";
     }
 
-    string getForward(size_t position, int num)
+    string getForward(size_t position, ulong num)
     {
         if (position + num < source.length)
              return source[position..position+num];


### PR DESCRIPTION
I had tried to build cook2 and got this errors:

```
cmdopt.d(96): Error: undefined identifier 'c'
lexer.d(224): Error: function lexer.Lexer.getForward (ulong position, int num) is not callable using argument types (ulong, ulong)
session.d(66): Error: undefined identifier 'c'
```

Here is my fix.